### PR TITLE
Clean up children

### DIFF
--- a/moi/group.py
+++ b/moi/group.py
@@ -81,12 +81,17 @@ class Group(object):
 
     def _traverse(self, id_):
         """Traverse groups and yield info dicts for jobs"""
-
         nodes = r_client.smembers(_children_key(id_))
         while nodes:
             current_id = nodes.pop()
 
-            details = self._decode(r_client.get(current_id))
+            details = r_client.get(current_id)
+            if details is None:
+                # child has expired or been deleted, remove from :children
+                r_client.srem(_children_key(id_), current_id)
+                continue
+
+            details = self._decode(details)
             if details['type'] == 'group':
                 children = r_client.smembers(_children_key(details['id']))
                 if children is not None:

--- a/moi/test/test_group.py
+++ b/moi/test/test_group.py
@@ -25,14 +25,42 @@ class GroupTests(TestCase):
         r_client.set('d', '{"type": "job", "id": "d", "name": "other job"}')
         r_client.set('e', '{"type": "job", "id": "e", "name": "other job e"}')
         self.obj = Group('testing')
+        self.to_delete = ['testing', 'testing:jobs', 'testing:children',
+                          'user-id-map', 'a', 'b', 'c', 'd', 'e']
 
     def tearDown(self):
-        r_client.delete('testing:jobs')
+        for key in self.to_delete:
+            r_client.delete(key)
 
     def test_init(self):
         self.assertEqual(self.obj.group_children, 'testing:children')
         self.assertEqual(self.obj.group_pubsub, 'testing:pubsub')
         self.assertEqual(self.obj.forwarder('foo'), None)
+
+    def test_traverse_simple(self):
+        exp = {'a', 'b', 'c'}
+        obs = {obj['id'] for obj in self.obj._traverse('testing')}
+        self.assertEqual(obs, exp)
+
+    def test_traverse_removed_child(self):
+        r_client.delete('b')
+        exp = {'a', 'c'}
+        obs = {obj['id'] for obj in self.obj._traverse('testing')}
+        self.assertEqual(obs, exp)
+        self.assertEqual(r_client.smembers('testing:children'), exp)
+
+    def test_traverse_complex(self):
+        r_client.sadd('testing:children', 'd')
+        r_client.sadd('d:children', 'd_a', 'd_b')
+        r_client.set('d', '{"type": "group", "id": "d", "name": "d"}')
+        r_client.set('d_a', '{"type": "job", "id": "d_a", "name": "d_a"}')
+        r_client.set('d_b', '{"type": "job", "id": "d_b", "name": "d_b"}')
+        self.to_delete.append('d:children')
+        self.to_delete.append('d_a')
+        self.to_delete.append('d_b')
+        exp = {'a', 'b', 'c', 'd', 'd_a', 'd_b'}
+        obs = {obj['id'] for obj in self.obj._traverse('testing')}
+        self.assertEqual(obs, exp)
 
     def test_del(self):
         pass  # unsure how to test


### PR DESCRIPTION
This will automatically clean up children in the case of redis key expiration, also adds tests for traverse